### PR TITLE
Fix create_li_maini_graph()

### DIFF
--- a/graph_tools/__init__.py
+++ b/graph_tools/__init__.py
@@ -1278,6 +1278,7 @@ class Graph:
                                              replace=False,
                                              p=prob):
                     _add_edge(u, v)
+        return self
 
     # import ----------------------------------------------------------------
     def import_graph(self, fmt, *args):


### PR DESCRIPTION
In the latest graph-tools, `create_li_maini_graph()` does not return the created graph as follows.
```python3
import graph_tools

g = graph_tools.Graph(directed=False)
g = g.create_li_maini_graph()
print(g) # -> None
```
Therefore, I simply added `return self` to the end of `create_li_maini_graph()`.